### PR TITLE
Use dynamic article titles from frontmatter

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,51 +237,22 @@
         </div>
 
         <div class="project-feed">
+          {%- for post in collections.post reversed -%}
           <!-- Where AI Value Accumulates -->
           <article class="project-row">
             <div class="project-meta">
-              <span class="project-year">2025</span>
+              <span class="project-year">{{ post.date | date: "%Y" }}</span>
               <span class="project-type">WRITING / AI</span>
             </div>
             <div class="project-main">
-              <h3>WHERE AI VALUE ACCUMULATES</h3>
+              <h3>{{ post.data.title }}</h3>
               <p>
-                Why 90% of AI's value will be captured by applications, not foundation models.
+                {{ post.data.description }}
               </p>
-              <a href="/blog/where-ai-value-accumulates/" class="action-link">READ ARTICLE -></a>
+              <a href="{{ post.url }}" class="action-link">READ ARTICLE -></a>
             </div>
           </article>
-
-          <!-- AI Txns -->
-          <article class="project-row">
-            <div class="project-meta">
-              <span class="project-year">2023</span>
-              <span class="project-type">WRITING / AI</span>
-            </div>
-            <div class="project-main">
-              <h3>HOW I USE AI TO TRACK HSA TRANSACTIONS</h3>
-              <p>
-                A deep dive into using LLMs to parse transaction data from receipts and bank statements for HSA
-                eligibility verification.
-              </p>
-              <a href="/blog/ai-txns/" class="action-link">READ ARTICLE -></a>
-            </div>
-          </article>
-
-          <!-- Abort Controller -->
-          <article class="project-row">
-            <div class="project-meta">
-              <span class="project-year">2023</span>
-              <span class="project-type">WRITING / REACT</span>
-            </div>
-            <div class="project-main">
-              <h3>YOU PROBABLY HAVE A RACE CONDITION</h3>
-              <p>
-                How to prevent race conditions in React effects using AbortController.
-              </p>
-              <a href="/blog/abort-controller/" class="action-link">READ ARTICLE -></a>
-            </div>
-          </article>
+          {%- endfor -%}
         </div>
       </section>
     </main>


### PR DESCRIPTION
Replaces hardcoded article titles/descriptions on the homepage with dynamic values pulled from markdown frontmatter, matching the previous blog.html behavior.